### PR TITLE
Remove Python 3.4 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
  - "2.7"
- - "3.4"
  - "3.5"
  - "3.6"
 


### PR DESCRIPTION
Fedora messaging is using Twisted and this is supported by python 3.5 or newer.